### PR TITLE
ignore keystore, apk builds and related metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea
+*.jks
+*.apk
+
+dev/app/release/output-metadata.json


### PR DESCRIPTION
Updating gitignore in develop as soon as possible to avoid publicly publishing keys in any way